### PR TITLE
Fix "$rawBody is empty" situation

### DIFF
--- a/src/XmlParser.php
+++ b/src/XmlParser.php
@@ -79,8 +79,10 @@ class XmlParser implements RequestParserInterface
 
         if ($parameters === false) {
             if ($this->throwException) {
-                $e = libxml_get_last_error();
-                throw new BadRequestHttpException('Invalid XML data in request body: ' . $e->message);
+                throw new BadRequestHttpException(
+                    'Invalid XML data in request body: '
+                    . (empty($rawBody) ? 'The body is empty' : libxml_get_last_error()->message)
+                );
             }
             return [];
         }


### PR DESCRIPTION
When the $rawBody is empty, the code fails when tries to run the "$e->message()", because the $e is not an object at that moment.

And of course jamguozhijun - thank you for the extension.